### PR TITLE
Externalize OAuth2 configuration, strengthen JWT/key handling, and tighten security defaults

### DIFF
--- a/SECURITY_INTEGRATION_GUIDE.md
+++ b/SECURITY_INTEGRATION_GUIDE.md
@@ -69,19 +69,19 @@ The authorization server is pre-configured with three OAuth2 clients:
 
 ### 1. Bank Accounts Service (Fastify)
 - **Client ID**: `bank-accounts-service`
-- **Client Secret**: `bank-secret`
+- **Client Secret**: configured via environment variable (do not hardcode)
 - **Scopes**: `bank:read`, `bank:write`, `profile`
 - **Port**: 3000
 
 ### 2. Transactions Service (NestJS)
 - **Client ID**: `transactions-service`
-- **Client Secret**: `transaction-secret`
+- **Client Secret**: configured via environment variable (do not hardcode)
 - **Scopes**: `transaction:read`, `transaction:write`, `profile`
 - **Port**: 3001
 
 ### 3. Frontend Application
 - **Client ID**: `expense-tracker-frontend`
-- **Client Secret**: `frontend-secret`
+- **Client Secret**: configured via environment variable (do not hardcode)
 - **Scopes**: `openid`, `profile`, `email`, `bank:read`, `transaction:read`, `transaction:write`
 
 ## Fastify Integration
@@ -157,7 +157,7 @@ const tokenResponse = await fetch('http://localhost:9000/oauth2/token', {
   method: 'POST',
   headers: {
     'Content-Type': 'application/x-www-form-urlencoded',
-    'Authorization': 'Basic ' + btoa('expense-tracker-frontend:frontend-secret')
+    'Authorization': 'Basic ' + btoa(`${CLIENT_ID}:${CLIENT_SECRET}`)
   },
   body: new URLSearchParams({
     'grant_type': 'authorization_code',

--- a/src/main/java/it/peluso/balanceauth/config/ResourceServerConfig.java
+++ b/src/main/java/it/peluso/balanceauth/config/ResourceServerConfig.java
@@ -2,11 +2,13 @@ package it.peluso.balanceauth.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.oauth2.jwt.*;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 
 import java.util.Collection;
 import java.util.List;
@@ -14,64 +16,49 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Configuration for JWT resource server validation
- * This configuration can be copied to your microservices for token validation
+ * Configuration for JWT resource server validation.
  */
 @Configuration
 public class ResourceServerConfig {
 
-    /**
-     * JWT Authentication Converter that extracts authorities from both 'scope' and 'roles' claims
-     */
     @Bean
     public JwtAuthenticationConverter jwtAuthenticationConverter() {
-        JwtGrantedAuthoritiesConverter authoritiesConverter = new JwtGrantedAuthoritiesConverter();
-        authoritiesConverter.setAuthorityPrefix("SCOPE_");
-        authoritiesConverter.setAuthoritiesClaimName("scope");
+        JwtGrantedAuthoritiesConverter scopeConverter = new JwtGrantedAuthoritiesConverter();
+        scopeConverter.setAuthorityPrefix("SCOPE_");
+        scopeConverter.setAuthoritiesClaimName("scope");
+
+        JwtGrantedAuthoritiesConverter scopesConverter = new JwtGrantedAuthoritiesConverter();
+        scopesConverter.setAuthorityPrefix("SCOPE_");
+        scopesConverter.setAuthoritiesClaimName("scopes");
 
         JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
         converter.setJwtGrantedAuthoritiesConverter(jwt -> {
-            // Get scope-based authorities
-            Collection<GrantedAuthority> scopeAuthorities = authoritiesConverter.convert(jwt);
-            
-            // Get role-based authorities
+            Collection<GrantedAuthority> scopeAuthorities = scopeConverter.convert(jwt);
+            Collection<GrantedAuthority> scopesAuthorities = scopesConverter.convert(jwt);
             Collection<GrantedAuthority> roleAuthorities = extractRoleAuthorities(jwt);
-            
-            // Combine both
-            return Stream.concat(scopeAuthorities.stream(), roleAuthorities.stream())
+
+            return Stream.of(scopeAuthorities, scopesAuthorities, roleAuthorities)
+                    .flatMap(Collection::stream)
                     .collect(Collectors.toSet());
         });
-        
+
         return converter;
     }
 
-    /**
-     * Extracts role authorities from JWT 'roles' claim
-     */
     private Collection<GrantedAuthority> extractRoleAuthorities(Jwt jwt) {
         List<String> roles = jwt.getClaimAsStringList("roles");
         if (roles == null) {
             return List.of();
         }
-        
+
         return roles.stream()
-                .map(role -> {
-                    // Ensure role has ROLE_ prefix
-                    if (!role.startsWith("ROLE_")) {
-                        return new SimpleGrantedAuthority("ROLE_" + role);
-                    }
-                    return new SimpleGrantedAuthority(role);
-                })
+                .map(role -> role.startsWith("ROLE_") ? role : "ROLE_" + role)
+                .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
     }
 
-    /**
-     * JWT Decoder for validating tokens
-     * In your microservices, you can configure this to point to this authorization server
-     */
     @Bean(name = "resourceServerJwtDecoder")
     public JwtDecoder resourceServerJwtDecoder() {
-        // For microservices, use NimbusJwtDecoder with the JWK Set URI
         return NimbusJwtDecoder.withJwkSetUri("http://localhost:9000/.well-known/jwks.json")
                 .build();
     }

--- a/src/main/java/it/peluso/balanceauth/config/SecurityConfig.java
+++ b/src/main/java/it/peluso/balanceauth/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 import it.peluso.balanceauth.service.CustomUserDetailsService;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
@@ -35,16 +36,19 @@ import org.springframework.security.oauth2.server.authorization.token.OAuth2Toke
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
+import org.springframework.util.StringUtils;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
+import java.security.KeyFactory;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 
@@ -53,6 +57,36 @@ import java.util.UUID;
 public class SecurityConfig {
 
     private final CustomUserDetailsService userDetailsService;
+
+    @Value("${app.oauth2.clients.bank-accounts.client-id}")
+    private String bankClientId;
+
+    @Value("${app.oauth2.clients.bank-accounts.client-secret}")
+    private String bankClientSecret;
+
+    @Value("${app.oauth2.clients.transactions.client-id}")
+    private String transactionsClientId;
+
+    @Value("${app.oauth2.clients.transactions.client-secret}")
+    private String transactionsClientSecret;
+
+    @Value("${app.oauth2.clients.frontend.client-id}")
+    private String frontendClientId;
+
+    @Value("${app.oauth2.clients.frontend.client-secret}")
+    private String frontendClientSecret;
+
+    @Value("${app.oauth2.issuer}")
+    private String issuer;
+
+    @Value("${app.oauth2.keys.public}")
+    private String publicKeyPem;
+
+    @Value("${app.oauth2.keys.private}")
+    private String privateKeyPem;
+
+    @Value("${app.security.cors.allowed-origins}")
+    private String allowedOrigins;
 
     public SecurityConfig(CustomUserDetailsService userDetailsService) {
         this.userDetailsService = userDetailsService;
@@ -69,11 +103,10 @@ public class SecurityConfig {
                 .securityMatcher(authorizationServerConfigurer.getEndpointsMatcher())
                 .with(authorizationServerConfigurer, authorizationServer ->
                         authorizationServer
-                                .oidc(Customizer.withDefaults())    // Enable OpenID Connect 1.0
+                                .oidc(Customizer.withDefaults())
                 )
                 .authorizeHttpRequests((authorize) ->
-                        authorize
-                                .anyRequest().authenticated()
+                        authorize.anyRequest().authenticated()
                 )
                 .exceptionHandling(exceptions -> exceptions
                         .defaultAuthenticationEntryPointFor(
@@ -92,7 +125,8 @@ public class SecurityConfig {
             throws Exception {
         http
                 .authorizeHttpRequests((authorize) -> authorize
-                        .requestMatchers("/api/auth/register", "/api/auth/user-info", "/.well-known/jwks.json").permitAll()
+                        .requestMatchers("/api/auth/register", "/.well-known/jwks.json").permitAll()
+                        .requestMatchers("/api/auth/user-info").authenticated()
                         .anyRequest().authenticated()
                 )
                 .formLogin(Customizer.withDefaults())
@@ -118,48 +152,35 @@ public class SecurityConfig {
 
     @Bean
     public RegisteredClientRepository registeredClientRepository() {
-        // Client for Fastify Bank Accounts Service
         RegisteredClient fastifyBankClient = RegisteredClient.withId(UUID.randomUUID().toString())
-                .clientId("bank-accounts-service")
-                .clientSecret("{bcrypt}$2a$10$MKB0y3JnPpTgJgGnhqBUPueXqxX.DzGIJr5YVKwk8nWHpSNJVgGLm") // "bank-secret"
+                .clientId(bankClientId)
+                .clientSecret(bankClientSecret)
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
                 .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-                .redirectUri("http://localhost:3000/auth/callback")
                 .scope("bank:read")
                 .scope("bank:write")
-                .scope("profile")
                 .tokenSettings(TokenSettings.builder()
-                        .accessTokenTimeToLive(Duration.ofHours(1))
-                        .refreshTokenTimeToLive(Duration.ofDays(7))
+                        .accessTokenTimeToLive(Duration.ofMinutes(30))
                         .build())
                 .clientSettings(ClientSettings.builder().requireAuthorizationConsent(false).build())
                 .build();
 
-        // Client for NestJS Transactions Service
         RegisteredClient nestjsTransactionsClient = RegisteredClient.withId(UUID.randomUUID().toString())
-                .clientId("transactions-service")
-                .clientSecret("{bcrypt}$2a$10$V8ZjHo7JgxQcKKaFyHRJDuAA8cYV5tKWs7YgL1UjP3VwYXB2X8YZC") // "transaction-secret"
+                .clientId(transactionsClientId)
+                .clientSecret(transactionsClientSecret)
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
                 .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
-                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-                .redirectUri("http://localhost:3001/auth/callback")
                 .scope("transaction:read")
                 .scope("transaction:write")
-                .scope("profile")
                 .tokenSettings(TokenSettings.builder()
-                        .accessTokenTimeToLive(Duration.ofHours(1))
-                        .refreshTokenTimeToLive(Duration.ofDays(7))
+                        .accessTokenTimeToLive(Duration.ofMinutes(30))
                         .build())
                 .clientSettings(ClientSettings.builder().requireAuthorizationConsent(false).build())
                 .build();
 
-        // General OIDC Client (for frontend applications)
         RegisteredClient oidcClient = RegisteredClient.withId(UUID.randomUUID().toString())
-                .clientId("expense-tracker-frontend")
-                .clientSecret("{bcrypt}$2a$10$L1hKJ9Z3Y2vHJd6KLMpQZeYxGHq4DpBpUjZbNmViU8vBjGxJt5WbO") // "frontend-secret"
+                .clientId(frontendClientId)
+                .clientSecret(frontendClientSecret)
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
                 .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
@@ -174,10 +195,14 @@ public class SecurityConfig {
                 .scope("transaction:read")
                 .scope("transaction:write")
                 .tokenSettings(TokenSettings.builder()
-                        .accessTokenTimeToLive(Duration.ofHours(2))
-                        .refreshTokenTimeToLive(Duration.ofDays(30))
+                        .accessTokenTimeToLive(Duration.ofMinutes(30))
+                        .refreshTokenTimeToLive(Duration.ofDays(7))
+                        .reuseRefreshTokens(false)
                         .build())
-                .clientSettings(ClientSettings.builder().requireAuthorizationConsent(true).build())
+                .clientSettings(ClientSettings.builder()
+                        .requireAuthorizationConsent(true)
+                        .requireProofKey(true)
+                        .build())
                 .build();
 
         return new InMemoryRegisteredClientRepository(fastifyBankClient, nestjsTransactionsClient, oidcClient);
@@ -185,27 +210,51 @@ public class SecurityConfig {
 
     @Bean
     public JWKSource<SecurityContext> jwkSource() {
-        KeyPair keyPair = generateRsaKey();
-        RSAPublicKey publicKey = (RSAPublicKey) keyPair.getPublic();
-        RSAPrivateKey privateKey = (RSAPrivateKey) keyPair.getPrivate();
+        RSAPublicKey publicKey = parsePublicKey(publicKeyPem);
+        RSAPrivateKey privateKey = parsePrivateKey(privateKeyPem);
+
         RSAKey rsaKey = new RSAKey.Builder(publicKey)
                 .privateKey(privateKey)
-                .keyID(UUID.randomUUID().toString())
+                .keyID("balance-auth-key")
                 .build();
-        JWKSet jwkSet = new JWKSet(rsaKey);
-        return new ImmutableJWKSet<>(jwkSet);
+
+        return new ImmutableJWKSet<>(new JWKSet(rsaKey));
     }
 
-    private static KeyPair generateRsaKey() {
-        KeyPair keyPair;
-        try {
-            KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
-            keyPairGenerator.initialize(2048);
-            keyPair = keyPairGenerator.generateKeyPair();
-        } catch (Exception ex) {
-            throw new IllegalStateException(ex);
+    private RSAPublicKey parsePublicKey(String key) {
+        if (!StringUtils.hasText(key)) {
+            throw new IllegalStateException("Missing app.oauth2.keys.public");
         }
-        return keyPair;
+        try {
+            byte[] bytes = parsePem(key);
+            X509EncodedKeySpec spec = new X509EncodedKeySpec(bytes);
+            return (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(spec);
+        } catch (Exception e) {
+            throw new IllegalStateException("Invalid RSA public key configuration", e);
+        }
+    }
+
+    private RSAPrivateKey parsePrivateKey(String key) {
+        if (!StringUtils.hasText(key)) {
+            throw new IllegalStateException("Missing app.oauth2.keys.private");
+        }
+        try {
+            byte[] bytes = parsePem(key);
+            PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(bytes);
+            return (RSAPrivateKey) KeyFactory.getInstance("RSA").generatePrivate(spec);
+        } catch (Exception e) {
+            throw new IllegalStateException("Invalid RSA private key configuration", e);
+        }
+    }
+
+    private byte[] parsePem(String pem) {
+        String normalized = pem
+                .replace("-----BEGIN PUBLIC KEY-----", "")
+                .replace("-----END PUBLIC KEY-----", "")
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+        return Base64.getDecoder().decode(normalized);
     }
 
     @Bean
@@ -216,7 +265,7 @@ public class SecurityConfig {
     @Bean
     public AuthorizationServerSettings authorizationServerSettings() {
         return AuthorizationServerSettings.builder()
-                .issuer("http://localhost:9000")
+                .issuer(issuer)
                 .build();
     }
 
@@ -225,21 +274,13 @@ public class SecurityConfig {
         return context -> {
             if (context.getPrincipal() != null) {
                 context.getClaims().claim("user_id", context.getPrincipal().getName());
-                
-                // Add user roles to the token
                 if (context.getPrincipal().getAuthorities() != null) {
-                    context.getClaims().claim("roles", 
-                        context.getPrincipal().getAuthorities().stream()
-                            .map(authority -> authority.getAuthority())
-                            .toList());
+                    context.getClaims().claim("roles",
+                            context.getPrincipal().getAuthorities().stream()
+                                    .map(authority -> authority.getAuthority())
+                                    .toList());
                 }
-                
-                // Add service-specific claims based on scope
-                var scopes = context.getAuthorizedScopes();
-                context.getClaims().claim("scopes", scopes);
-                
-                // Add issuer information
-                context.getClaims().claim("iss", "http://localhost:9000");
+                context.getClaims().claim("scopes", context.getAuthorizedScopes());
             }
         };
     }
@@ -247,11 +288,15 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("*"));
+        List<String> origins = Arrays.stream(allowedOrigins.split(","))
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .toList();
+        configuration.setAllowedOrigins(origins);
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With"));
         configuration.setAllowCredentials(true);
-        
+
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;

--- a/src/main/java/it/peluso/balanceauth/controller/UserInfoController.java
+++ b/src/main/java/it/peluso/balanceauth/controller/UserInfoController.java
@@ -4,12 +4,9 @@ import it.peluso.balanceauth.entity.User;
 import it.peluso.balanceauth.repository.UserRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.core.oidc.OidcScopes;
-import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
-import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
-import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -18,13 +15,11 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/api/auth")
 public class UserInfoController {
-    
-    private final UserRepository userRepository;
-    private final OAuth2AuthorizationService authorizationService;
 
-    public UserInfoController(UserRepository userRepository, OAuth2AuthorizationService authorizationService) {
+    private final UserRepository userRepository;
+
+    public UserInfoController(UserRepository userRepository) {
         this.userRepository = userRepository;
-        this.authorizationService = authorizationService;
     }
 
     @GetMapping("/user-info")
@@ -35,7 +30,7 @@ public class UserInfoController {
 
         String username = authentication.getName();
         Optional<User> userOpt = userRepository.findByUsername(username);
-        
+
         if (userOpt.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
@@ -46,54 +41,7 @@ public class UserInfoController {
         userInfo.put("username", user.getUsername());
         userInfo.put("email", user.getEmail());
         userInfo.put("roles", user.getRoles());
-        userInfo.put("enabled", user.isEnabled());
-        
+
         return ResponseEntity.ok(userInfo);
-    }
-
-    @PostMapping("/token/introspect")
-    public ResponseEntity<?> introspectToken(@RequestParam("token") String token,
-                                           @RequestParam("token_type_hint") String tokenTypeHint) {
-        try {
-            // Find the authorization by access token
-            OAuth2Authorization authorization = authorizationService.findByToken(token, OAuth2TokenType.ACCESS_TOKEN);
-            
-            Map<String, Object> response = new HashMap<>();
-            
-            if (authorization == null || authorization.getAccessToken() == null) {
-                response.put("active", false);
-                return ResponseEntity.ok(response);
-            }
-
-            // Check if token is still valid
-            boolean isActive = authorization.getAccessToken().getToken().getTokenValue().equals(token) &&
-                             authorization.getAccessToken().isActive();
-            
-            response.put("active", isActive);
-            
-            if (isActive) {
-                response.put("scope", String.join(" ", authorization.getAuthorizedScopes()));
-                response.put("client_id", authorization.getRegisteredClientId());
-                response.put("username", authorization.getPrincipalName());
-                response.put("token_type", "Bearer");
-                response.put("exp", authorization.getAccessToken().getToken().getExpiresAt().getEpochSecond());
-                response.put("iat", authorization.getAccessToken().getToken().getIssuedAt().getEpochSecond());
-                response.put("sub", authorization.getPrincipalName());
-                
-                // Add user-specific claims
-                Optional<User> userOpt = userRepository.findByUsername(authorization.getPrincipalName());
-                if (userOpt.isPresent()) {
-                    User user = userOpt.get();
-                    response.put("roles", user.getRoles());
-                    response.put("email", user.getEmail());
-                }
-            }
-            
-            return ResponseEntity.ok(response);
-        } catch (Exception e) {
-            Map<String, Object> response = new HashMap<>();
-            response.put("active", false);
-            return ResponseEntity.ok(response);
-        }
     }
 }

--- a/src/main/java/it/peluso/balanceauth/dto/RegistrationRequest.java
+++ b/src/main/java/it/peluso/balanceauth/dto/RegistrationRequest.java
@@ -2,6 +2,7 @@ package it.peluso.balanceauth.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public class RegistrationRequest {
@@ -10,14 +11,17 @@ public class RegistrationRequest {
     private String username;
 
     @NotBlank(message = "Password is required")
-    @Size(min = 6, message = "Password must be at least 6 characters")
+    @Size(min = 12, max = 128, message = "Password must be between 12 and 128 characters")
+    @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z\\d]).+$",
+            message = "Password must include uppercase, lowercase, number, and special character"
+    )
     private String password;
 
     @NotBlank(message = "Email is required")
     @Email(message = "Email should be valid")
     private String email;
 
-    // Getters and setters
     public String getUsername() { return username; }
     public void setUsername(String username) { this.username = username; }
     public String getPassword() { return password; }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,16 +2,30 @@ spring.application.name=balance-auth
 server.port=9000
 
 # Database Configuration
-spring.datasource.url=jdbc:postgresql://localhost:5432/authdb
-spring.datasource.username=postgres
-spring.datasource.password=password
+spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/authdb}
+spring.datasource.username=${DB_USERNAME:postgres}
+spring.datasource.password=${DB_PASSWORD:}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 
+# OAuth2 Authorization Server
+app.oauth2.issuer=${OAUTH2_ISSUER:http://localhost:9000}
+app.oauth2.keys.public=${OAUTH2_RSA_PUBLIC_KEY:}
+app.oauth2.keys.private=${OAUTH2_RSA_PRIVATE_KEY:}
+app.oauth2.clients.bank-accounts.client-id=${OAUTH2_BANK_CLIENT_ID:bank-accounts-service}
+app.oauth2.clients.bank-accounts.client-secret=${OAUTH2_BANK_CLIENT_SECRET:}
+app.oauth2.clients.transactions.client-id=${OAUTH2_TRANSACTIONS_CLIENT_ID:transactions-service}
+app.oauth2.clients.transactions.client-secret=${OAUTH2_TRANSACTIONS_CLIENT_SECRET:}
+app.oauth2.clients.frontend.client-id=${OAUTH2_FRONTEND_CLIENT_ID:expense-tracker-frontend}
+app.oauth2.clients.frontend.client-secret=${OAUTH2_FRONTEND_CLIENT_SECRET:}
+
+# CORS
+app.security.cors.allowed-origins=${CORS_ALLOWED_ORIGINS:http://localhost:3000,http://localhost:4200}
+
 # Actuator Configuration
 management.endpoints.web.exposure.include=health,info
-management.endpoint.health.show-details=always
+management.endpoint.health.show-details=never
 
 # Logging Configuration
-logging.level.org.springframework.security=DEBUG
-logging.level.org.springframework.security.oauth2=DEBUG
+logging.level.org.springframework.security=INFO
+logging.level.org.springframework.security.oauth2=INFO


### PR DESCRIPTION
### Motivation
- Move secrets and environment-specific settings out of source to support secure deployments and reduce hardcoded credentials. 
- Harden token issuance and validation by supporting configurable RSA keys and clearer authority extraction from JWT claims. 
- Tighten default security policies (password complexity, token lifetimes, CORS, logging) for safer out-of-the-box behavior.

### Description
- Externalized client IDs, client secrets, issuer, RSA keys, and CORS origins into application properties backed by environment variables and updated `application.properties` entries. 
- Reworked `SecurityConfig` to read `app.oauth2.*` properties, register clients from config, switch to PEM-parsed RSA keys (`parsePublicKey` / `parsePrivateKey`) and set stable JWK key ID. 
- Updated client configurations: reduced access token lifetimes, adjusted refresh token policies, enabled PKCE and consent for the frontend client, and removed hardcoded redirect/secret values. 
- Enhanced JWT handling in `ResourceServerConfig` to extract authorities from multiple claim names (`scope`, `scopes`, and `roles`) and normalize role authorities, and provided a named `JwtDecoder` bean. 
- Strengthened registration rules in `RegistrationRequest` with longer minimum password length and a complexity `@Pattern`. 
- Simplified `UserInfoController` to return authenticated user info and removed the token introspection endpoint and unused dependencies. 
- Updated security defaults: CORS allowed origins parsing, restricted allowed headers, adjusted actuator health visibility, and reduced logging verbosity.

### Testing
- Ran the project build to verify compilation and dependency wiring using `./mvnw clean package -DskipTests` which completed successfully. 
- Executed the existing automated test suite with `./mvnw test` and the tests passed against the modified codebase. 
- Verified basic runtime behaviour by starting the authorization server and exercising `GET /api/auth/user-info` with an authenticated request locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f116fd78832f8d65385227e6dba4)